### PR TITLE
Add ad-hoc decoders architecture.

### DIFF
--- a/src/entity/decoder.rs
+++ b/src/entity/decoder.rs
@@ -1,0 +1,96 @@
+//! Resource decoders.
+
+use crate::{
+  entity::{Entity, EntityEvent},
+  system::{resource::ResourceManager, Publisher},
+};
+use colored::Colorize as _;
+use std::{error::Error, marker::PhantomData, path::Path};
+
+/// Resource decoder.
+pub trait Decoder: Sized {
+  /// File extension this decoder accepts.
+  const EXT: &'static str;
+
+  /// File sub extension this decoder accepts.
+  ///
+  /// If sub extensions don’t make sense for your implementor, simply use the empty string `""`.
+  const SUB_EXT: &'static str;
+
+  /// Decoder error.
+  type Err: Error;
+
+  /// Load a resource from a path.
+  fn load_from_file(
+    resources: &mut ResourceManager<Entity>,
+    publisher: &mut impl Publisher<EntityEvent>,
+    path: impl AsRef<Path>,
+  ) -> Result<(), Self::Err>;
+}
+
+/// Type-level tuple of decoders.
+#[derive(Debug)]
+pub struct Tuple<A, B> {
+  _phantom: PhantomData<(A, B)>,
+}
+
+/// Type that contains decoders.
+pub trait HasDecoder {
+  fn load_from_file(
+    resources: &mut ResourceManager<Entity>,
+    publisher: &mut impl Publisher<EntityEvent>,
+    ext: impl AsRef<str>,
+    sub_ext: impl AsRef<str>,
+    path: impl AsRef<Path>,
+  ) -> bool;
+}
+
+impl<D> HasDecoder for D
+where
+  D: Decoder,
+{
+  fn load_from_file(
+    resources: &mut ResourceManager<Entity>,
+    publisher: &mut impl Publisher<EntityEvent>,
+    ext: impl AsRef<str>,
+    sub_ext: impl AsRef<str>,
+    path: impl AsRef<Path>,
+  ) -> bool {
+    let path = path.as_ref();
+    let was_active = ext.as_ref() == D::EXT && sub_ext.as_ref() == D::SUB_EXT;
+
+    if was_active {
+      if let Err(err) = <D as Decoder>::load_from_file(resources, publisher, path) {
+        log::error!(
+          "cannot load {} {}: {}",
+          "obj".yellow().italic(),
+          path.display().to_string().purple().italic(),
+          err,
+        );
+      }
+    }
+
+    was_active
+  }
+}
+
+impl<A, B> HasDecoder for Tuple<A, B>
+where
+  A: HasDecoder,
+  B: HasDecoder,
+{
+  fn load_from_file(
+    resources: &mut ResourceManager<Entity>,
+    publisher: &mut impl Publisher<EntityEvent>,
+    ext: impl AsRef<str>,
+    sub_ext: impl AsRef<str>,
+    path: impl AsRef<Path>,
+  ) -> bool {
+    let ext = ext.as_ref();
+    let sub_ext = sub_ext.as_ref();
+    let path = path.as_ref();
+
+    A::load_from_file(resources, publisher, ext, sub_ext, path)
+      || B::load_from_file(resources, publisher, ext, sub_ext, path)
+  }
+}

--- a/src/entity/default_decoders.rs
+++ b/src/entity/default_decoders.rs
@@ -1,0 +1,5 @@
+//! Default decoders.
+
+use crate::entity::{decoder::Tuple, mesh::OBJDecoder, parameter::ParameterDecoder};
+
+pub type Decoders = Tuple<OBJDecoder, ParameterDecoder>;

--- a/src/entity/material.rs
+++ b/src/entity/material.rs
@@ -1,0 +1,4 @@
+//! Materials and visual effects (VFX).
+
+/// A visual effect.
+pub struct VFX {}

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -109,8 +109,6 @@ impl GraphicsSystem {
 
   /// React an entity.
   fn accept_entity(&mut self, handle: Handle<Entity>, entity: Entity) {
-    log::debug!("accepting entity {}", handle);
-
     match entity {
       Entity::Mesh(mesh) => self.accept_mesh(handle, mesh),
       _ => (),

--- a/src/graphics/material.rs
+++ b/src/graphics/material.rs
@@ -1,0 +1,3 @@
+//! Material definitions.
+//!
+//! Materials are shader-like objects allowing to display meshes.

--- a/src/runtime/main.rs
+++ b/src/runtime/main.rs
@@ -64,7 +64,8 @@ impl System for Runtime {
 
     // entity system
     let entity_uid = self.create_system("entity");
-    let mut entity_system = EntitySystem::new(self.system_addr(), entity_uid, cli.entity_root_path);
+    let mut entity_system: EntitySystem =
+      EntitySystem::new(self.system_addr(), entity_uid, cli.entity_root_path);
     let entity_system_addr = entity_system.system_addr();
 
     // graphics system


### PR DESCRIPTION
This way of doing allows to select-by-type the decoder we want enabled.
This greatly improve the extensibility of decoders without having to
modify any line of existing code to add new decoders (besides the
default decoder type).